### PR TITLE
Brew formula update for auth0-cli version v1.10.1

### DIFF
--- a/auth0.rb
+++ b/auth0.rb
@@ -5,13 +5,13 @@
 class Auth0 < Formula
   desc "Build, manage and test your Auth0 integrations from the command line"
   homepage "https://auth0.github.io/auth0-cli"
-  version "1.10.0"
+  version "1.10.1"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/auth0/auth0-cli/releases/download/v1.10.0/auth0-cli_1.10.0_Darwin_x86_64.tar.gz"
-      sha256 "1ae65ee91c7fdd69e040df1c4320520ed9d02d64cd29dea9b8b1d235fdc5ca16"
+      url "https://github.com/auth0/auth0-cli/releases/download/v1.10.1/auth0-cli_1.10.1_Darwin_x86_64.tar.gz"
+      sha256 "315193a816532291e68232e1079c8dfbf3bc6977a8060a2becdd19fcb0fc39dd"
 
       def install
         bin.install "auth0"
@@ -22,8 +22,8 @@ class Auth0 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/auth0/auth0-cli/releases/download/v1.10.0/auth0-cli_1.10.0_Darwin_arm64.tar.gz"
-      sha256 "39514bfcaa6487ad1a9829385323c438b36466104a3526af02a8e93838fcad86"
+      url "https://github.com/auth0/auth0-cli/releases/download/v1.10.1/auth0-cli_1.10.1_Darwin_arm64.tar.gz"
+      sha256 "8fa2d949eefb2dd5c3ed98afaeb8558b346b7de4a054bd258d0f773ea74f4bae"
 
       def install
         bin.install "auth0"
@@ -38,8 +38,8 @@ class Auth0 < Formula
   on_linux do
     if Hardware::CPU.intel?
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/auth0/auth0-cli/releases/download/v1.10.0/auth0-cli_1.10.0_Linux_x86_64.tar.gz"
-        sha256 "1bc86ca37909f7881517807e3c581c16a647866f151749ef90e2b2c9964ae211"
+        url "https://github.com/auth0/auth0-cli/releases/download/v1.10.1/auth0-cli_1.10.1_Linux_x86_64.tar.gz"
+        sha256 "09c1b55c5d38693d1ba3895babb20dafae28814c37c1ac102d8f6e6980565058"
 
         def install
           bin.install "auth0"
@@ -52,8 +52,8 @@ class Auth0 < Formula
     end
     if Hardware::CPU.arm?
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/auth0/auth0-cli/releases/download/v1.10.0/auth0-cli_1.10.0_Linux_arm64.tar.gz"
-        sha256 "ff07f1fa1b73fc0d2111639686f74a94892746b92287fc8e7919466996f837bb"
+        url "https://github.com/auth0/auth0-cli/releases/download/v1.10.1/auth0-cli_1.10.1_Linux_arm64.tar.gz"
+        sha256 "ea8a66f8ca879d44df49bca1525d3611402a552e8a446cd2a065eb2d4dbb36f0"
 
         def install
           bin.install "auth0"


### PR DESCRIPTION
This PR updates the Homebrew formula for version v1.10.1.