### PR TITLE
Brew formula update for auth0-cli version v1.17.1

### DIFF
--- a/auth0.rb
+++ b/auth0.rb
@@ -5,13 +5,13 @@
 class Auth0 < Formula
   desc "Build, manage and test your Auth0 integrations from the command line"
   homepage "https://auth0.github.io/auth0-cli"
-  version "1.17.0"
+  version "1.17.1"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/auth0/auth0-cli/releases/download/v1.17.0/auth0-cli_1.17.0_Darwin_x86_64.tar.gz"
-      sha256 "93c6f0ee82523c1ce67aa665d2b590d6984fceb3256f3ab3aa5628fd70f3a04b"
+      url "https://github.com/auth0/auth0-cli/releases/download/v1.17.1/auth0-cli_1.17.1_Darwin_x86_64.tar.gz"
+      sha256 "faf71c7965e8d253caf4ca916c6673042db715f6444c57d6c74f5168048f0b51"
 
       def install
         bin.install "auth0"
@@ -22,8 +22,8 @@ class Auth0 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/auth0/auth0-cli/releases/download/v1.17.0/auth0-cli_1.17.0_Darwin_arm64.tar.gz"
-      sha256 "0cc0af5f81d31b746d4a4982cb739df743f038f1e4caf1100e12f597f752e1eb"
+      url "https://github.com/auth0/auth0-cli/releases/download/v1.17.1/auth0-cli_1.17.1_Darwin_arm64.tar.gz"
+      sha256 "86319b4dfd2208325f2907e792eb2b66cb168286bea07ab7ba48cb5c38ddea17"
 
       def install
         bin.install "auth0"
@@ -38,8 +38,8 @@ class Auth0 < Formula
   on_linux do
     if Hardware::CPU.intel?
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/auth0/auth0-cli/releases/download/v1.17.0/auth0-cli_1.17.0_Linux_x86_64.tar.gz"
-        sha256 "ebd81ecf5fbf19b6fa0034c76c10b8d26b4f707c42759f99a9655342efcc71ce"
+        url "https://github.com/auth0/auth0-cli/releases/download/v1.17.1/auth0-cli_1.17.1_Linux_x86_64.tar.gz"
+        sha256 "b9ad5c35de82fb283a0e0467bb1d6082572fdebce7d237c9f75d292f6a22d375"
 
         def install
           bin.install "auth0"
@@ -52,8 +52,8 @@ class Auth0 < Formula
     end
     if Hardware::CPU.arm?
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/auth0/auth0-cli/releases/download/v1.17.0/auth0-cli_1.17.0_Linux_arm64.tar.gz"
-        sha256 "615d127b10364ec57493a3d4309b09696b7e0a53988658f438ddb5bfdb5e0130"
+        url "https://github.com/auth0/auth0-cli/releases/download/v1.17.1/auth0-cli_1.17.1_Linux_arm64.tar.gz"
+        sha256 "9959308bf9dbbb39420cb1d3a1a92c07f76b195df52fc553d534061f4027f714"
 
         def install
           bin.install "auth0"


### PR DESCRIPTION
This PR updates the Homebrew formula for version v1.17.1.